### PR TITLE
Add experimental support for Clickteam installers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 /cache/
 /temp/
 /plugins/
+/cicdec/
 sc4pac-plugins.json
 sc4pac-plugins-lock.json
 sc4pac-credentials.properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- support for extracting Clickteam exe-installers using the external program `cicdec.exe`.
+  On macOS and Linux, this requires [mono](https://www.mono-project.com/docs/getting-started/install/) to be installed on your system.
+  Assets containing Clickteam installers must include the new `archiveType` property in the metadata.
+
 ### Changed
 - decreased caching period of channel table-of-contents file from 24 hours to 30 minutes to receive package updates sooner
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Currently, this program only comes with a command-line interface (CLI).
 - Prerequisites:
   - Java 8+ (https://adoptium.net/installation/)
   - enough disk space
+  - Mono ([macOS](https://www.mono-project.com/docs/getting-started/install/)/[Linux](https://repology.org/project/mono/versions), not needed on Windows):
+    This is optional and only needed for a few packages that originally use an installer.
 - [Download the latest release](https://github.com/memo33/sc4pac-tools/releases/latest)
   and extract the contents to any location in your user directory (for example, your Desktop).
 - Open a shell in the new directory (e.g. on Windows, open the folder and type `cmd` in the address bar of the explorer window)

--- a/channel-testing/template-empty.yaml
+++ b/channel-testing/template-empty.yaml
@@ -32,3 +32,7 @@ assetId: "<unique-id>"
 version: "<version>"
 lastModified: "<ISO-8601-timestamp>"
 url: "<asset-url>"
+
+# archiveType:
+#   format: Clickteam
+#   version: "40"  # possible versions are 40, 35, 30, 24, 20

--- a/channel-testing/yaml/templates/package-template-basic.yaml
+++ b/channel-testing/yaml/templates/package-template-basic.yaml
@@ -12,6 +12,11 @@ lastModified: "2023-07-29T21:33:57Z"
 # The direct download link to the artifact (supports zip files, jar files, and jar, zip, 7z or NSIS exe files contained in zip files)
 url: "http://localhost:8090/files/package-d.zip"
 
+# Assets containing a Clickteam exe-installer need to include this `archiveType` section with the correct installer version number:
+# archiveType:
+#   format: Clickteam
+#   version: "40"  # possible versions are 40, 35, 30, 24, 20
+
 ---
 # The following section describes a package.
 # Packages are collections of files that can be installed on user request.

--- a/sc4pac
+++ b/sc4pac
@@ -8,4 +8,13 @@
 
 
 SCRIPTDIR="${0%/*}"
+
+# The environment variable `SC4PAC_MONO_CMD` is only needed on Linux and macOS and is set here if not defined.
+# If you happen to run this script on Windows without Mono installed, remove the environment variable.
+: ${SC4PAC_MONO_CMD="mono"}
+export SC4PAC_MONO_CMD
+
+: ${SC4PAC_CICDEC_CMD="${SCRIPTDIR}/cicdec/cicdec.exe"}
+export SC4PAC_CICDEC_CMD
+
 java -jar "${SCRIPTDIR}/target/scala-3.3.0/sc4pac-cli.jar" "$@"

--- a/sc4pac
+++ b/sc4pac
@@ -9,12 +9,10 @@
 
 SCRIPTDIR="${0%/*}"
 
-# The environment variable `SC4PAC_MONO_CMD` is only needed on Linux and macOS and is set here if not defined.
+# We set defaults for environment variables if they are not defined.
+# The environment variable `SC4PAC_MONO_CMD` is only needed on Linux and macOS.
 # If you happen to run this script on Windows without Mono installed, remove the environment variable.
-: ${SC4PAC_MONO_CMD="mono"}
-export SC4PAC_MONO_CMD
-
-: ${SC4PAC_CICDEC_CMD="${SCRIPTDIR}/cicdec/cicdec.exe"}
-export SC4PAC_CICDEC_CMD
+export SC4PAC_MONO_CMD="${SC4PAC_MONO_CMD-"mono"}"
+export SC4PAC_CICDEC_CMD="${SC4PAC_CICDEC_CMD-"${SCRIPTDIR}/cicdec/cicdec.exe"}"
 
 java -jar "${SCRIPTDIR}/target/scala-3.3.0/sc4pac-cli.jar" "$@"

--- a/shared/shared/src/main/scala/sc4pac/shared.scala
+++ b/shared/shared/src/main/scala/sc4pac/shared.scala
@@ -82,12 +82,19 @@ abstract class SharedData {
     implicit val packageAssetRw: ReadWriter[PackageAsset] = ReadWriter.merge(Asset.assetRw, Package.packageRw)
   }
 
+  case class ArchiveType(format: String, version: String) derives ReadWriter
+  object ArchiveType {
+    val clickteamFormat = "Clickteam"
+    // val clickteamVersions = Seq(20, 24, 30, 35, 40)  // supported by cicdec 3.0.1
+  }
+
   @upickle.implicits.key("Asset")
   case class Asset(
     assetId: String,
     version: String,
     url: String,
     lastModified: Instant = null.asInstanceOf[Instant],
+    archiveType: Option[ArchiveType] = None,
     requiredBy: Seq[BareModule] = Seq.empty  // optional and only informative (mangles all variants and versions, is limited to one channel,
                                              // can easily become outdated since json files are cached indefinitely)
   ) extends PackageAsset /*derives ReadWriter*/ {

--- a/src/main/scala/sc4pac/ChannelUtil.scala
+++ b/src/main/scala/sc4pac/ChannelUtil.scala
@@ -46,9 +46,10 @@ object ChannelUtil {
     assetId: String,
     version: String,
     url: String,
-    lastModified: java.time.Instant = null
+    lastModified: java.time.Instant = null,
+    archiveType: JD.ArchiveType = null,
   ) derives ReadWriter {  // the difference to JD.Asset is that JD.Asset is part of a sealed trait requiring a `$type` field
-    def toAsset = JD.Asset(assetId = assetId, version = version, url = url, lastModified = lastModified, requiredBy = Nil)
+    def toAsset = JD.Asset(assetId = assetId, version = version, url = url, lastModified = lastModified, archiveType = Option(archiveType), requiredBy = Nil)
   }
 
   private def parseCirceJson[A : Reader](j: Json): IO[upickle.core.Abort | IllegalArgumentException, A] = {

--- a/src/main/scala/sc4pac/Constants.scala
+++ b/src/main/scala/sc4pac/Constants.scala
@@ -66,6 +66,15 @@ object Constants {
     */
   lazy val simtropolisCookie: Option[String] = Option(System.getenv("SC4PAC_SIMTROPOLIS_COOKIE")).filter(_.nonEmpty)
 
+  /* On non-Windows platforms, cicdec is invoked by `mono cicdec [args]`, but on Windows Mono is not required: `cicdec [args]`.
+   * We choose reasonable defaults, but allow customizing these two commands via environment variables (which are set in the launch scripts).
+   * Note that these commands must consist of a single command (not multiple space-separated commands).
+   * If `cicdec` is in your path, these environment variables are not needed.
+   */
+  lazy val monoCommand: Option[String] = Option(System.getenv("SC4PAC_MONO_CMD")).filter(_.nonEmpty)
+  lazy val cicdecCommand: Seq[String] =
+    monoCommand.toSeq ++ Seq(Option(System.getenv("SC4PAC_CICDEC_CMD")).filter(_.nonEmpty).getOrElse("cicdec"))
+
   def isSc4pacAsset(module: Module): Boolean = module.organization == Constants.sc4pacAssetOrg
 
   lazy val isInteractive: Boolean = try {

--- a/src/main/scala/sc4pac/Constants.scala
+++ b/src/main/scala/sc4pac/Constants.scala
@@ -28,7 +28,8 @@ object Constants {
   // 1: initial version
   // 2: DLL support and single-file assets
   // 3: rar support
-  val channelSchemeVersions: Range = 1 to 3  // supported versions
+  // 4: Clickteam installer support
+  val channelSchemeVersions: Range = 1 to 4  // supported versions
 
   val bufferSizeExtract = 64 * 1024  // 64 kiB, bounded by disk speed
   val bufferSizeDownload = 1024 * 1024  // 1 MiB, bounded by download speed

--- a/src/main/scala/sc4pac/Data.scala
+++ b/src/main/scala/sc4pac/Data.scala
@@ -164,7 +164,8 @@ object JsonData extends SharedData {
           assetId = dep.assetId.value,
           version = dep.version,
           url = dep.url,
-          lastModified = dep.lastModified.getOrElse(null)
+          lastModified = dep.lastModified.getOrElse(null),
+          archiveType = None  // not needed in lock file, as only version info is needed to determine if previously installed files are outdated
         ))
       )
     }

--- a/src/main/scala/sc4pac/Resolution.scala
+++ b/src/main/scala/sc4pac/Resolution.scala
@@ -60,19 +60,24 @@ object Resolution {
     }
   }
 
-  /** An sc4pac asset dependency: a leaf in the dependency tree. */
+  /** An sc4pac asset dependency: a leaf in the dependency tree.
+    * This class contains the functionally relevant internal data.
+    * In contrast, `JD.Asset` is merely used for JSON-serialization.
+    */
   final case class DepAsset(
     assetId: C.ModuleName,
     version: String,
     url: String,
-    lastModified: Option[java.time.Instant]
+    lastModified: Option[java.time.Instant],
+    archiveType: Option[JD.ArchiveType],
   ) extends Dep {
     def isSc4pacAsset: Boolean = true
     def toBareDep: BareAsset = BareAsset(assetId)
   }
   object DepAsset {
     def fromAsset(asset: JD.Asset): DepAsset =
-      DepAsset(assetId = ModuleName(asset.assetId), version = asset.version, url = asset.url, lastModified = Option(asset.lastModified))
+      DepAsset(assetId = ModuleName(asset.assetId), version = asset.version, url = asset.url,
+        lastModified = Option(asset.lastModified), archiveType = asset.archiveType)
   }
 
   /** An sc4pac metadata package dependency. */

--- a/src/main/scala/sc4pac/extractor.scala
+++ b/src/main/scala/sc4pac/extractor.scala
@@ -18,7 +18,7 @@ object Extractor {
   }
 
   private def tryExtractClickteam(file: java.io.File, targetDir: os.Path) = {
-    val args = Seq("cicdec", file.getPath, targetDir.toString)
+    val args = Constants.cicdecCommand ++ Seq(file.getPath, targetDir.toString)
     val result = os.proc(args).call(
       cwd = os.pwd,
       check = false,

--- a/src/main/scala/sc4pac/extractor.scala
+++ b/src/main/scala/sc4pac/extractor.scala
@@ -18,9 +18,9 @@ object Extractor {
   }
 
   private def tryExtractClickteam(file: java.io.File, targetDir: os.Path, logger: Logger) = {
-    logger.debug(s"Attempting to extract as Clickteam exe installer.")
-    val args = Constants.cicdecCommand ++ Seq(file.getPath, targetDir.toString)
-    val result = os.proc(args).call(
+    val args = Seq(file.getPath, targetDir.toString)
+    logger.debug(s"""Attempting to extract Clickteam exe installer "${args(0)}" to "${args(1)}"""")
+    val result = os.proc(Constants.cicdecCommand ++ args).call(
       cwd = os.pwd,
       check = false,
       mergeErrIntoOut = true,
@@ -225,7 +225,11 @@ object Extractor {
       val archivePath = os.Path(cache.localFile(archiveUrl), scopeRoot)
       val cachePath = os.Path(cache.location, scopeRoot)
       val archiveSubPath = archivePath.subRelativeTo(cachePath)
-      JarExtraction(jarsRoot / archiveSubPath)
+      // we hash the the archiveSubPath to keep paths short
+      val hash = java.security.MessageDigest.getInstance("SHA-1")
+        .digest(archiveSubPath.toString.getBytes("UTF-8"))
+        .take(4).map("%02x".format(_)).mkString // 4 bytes = 8 hex characters
+      JarExtraction(jarsRoot / hash)
     }
   }
 

--- a/src/scripts/dist.sh
+++ b/src/scripts/dist.sh
@@ -7,3 +7,6 @@ VERSION=$(sed build.sbt -ne 's/^ThisBuild \/ version := .\(.*\)./\1/p')
 OUT="target/dist/sc4pac-${VERSION}.zip"
 rm -f "$OUT"
 zip --junk-paths "$OUT" target/scala-3.3.0/sc4pac-cli.jar src/scripts/sc4pac src/scripts/sc4pac.bat README.md
+
+# cicdec was manually installed at ./cicdec/ and is bundled with our software
+zip -r "$OUT" cicdec

--- a/src/scripts/sc4pac
+++ b/src/scripts/sc4pac
@@ -6,4 +6,13 @@
 
 
 SCRIPTDIR="${0%/*}"
+
+# The environment variable `SC4PAC_MONO_CMD` is only needed on Linux and macOS and is set here if not defined.
+# If you happen to run this script on Windows without Mono installed, remove the environment variable.
+: ${SC4PAC_MONO_CMD="mono"}
+export SC4PAC_MONO_CMD
+
+: ${SC4PAC_CICDEC_CMD="${SCRIPTDIR}/cicdec/cicdec.exe"}
+export SC4PAC_CICDEC_CMD
+
 java -jar "$SCRIPTDIR/sc4pac-cli.jar" "$@"

--- a/src/scripts/sc4pac
+++ b/src/scripts/sc4pac
@@ -7,12 +7,10 @@
 
 SCRIPTDIR="${0%/*}"
 
-# The environment variable `SC4PAC_MONO_CMD` is only needed on Linux and macOS and is set here if not defined.
+# We set defaults for environment variables if they are not defined.
+# The environment variable `SC4PAC_MONO_CMD` is only needed on Linux and macOS.
 # If you happen to run this script on Windows without Mono installed, remove the environment variable.
-: ${SC4PAC_MONO_CMD="mono"}
-export SC4PAC_MONO_CMD
-
-: ${SC4PAC_CICDEC_CMD="${SCRIPTDIR}/cicdec/cicdec.exe"}
-export SC4PAC_CICDEC_CMD
+export SC4PAC_MONO_CMD="${SC4PAC_MONO_CMD-"mono"}"
+export SC4PAC_CICDEC_CMD="${SC4PAC_CICDEC_CMD-"${SCRIPTDIR}/cicdec/cicdec.exe"}"
 
 java -jar "$SCRIPTDIR/sc4pac-cli.jar" "$@"

--- a/src/scripts/sc4pac.bat
+++ b/src/scripts/sc4pac.bat
@@ -10,4 +10,7 @@ REM     .\sc4pac
 
 
 SET SCRIPTDIR=%~dp0.
+
+IF "%SC4PAC_CICDEC_CMD%"=="" SET "SC4PAC_CICDEC_CMD=%SCRIPTDIR%\cicdec\cicdec.exe"
+
 java -jar "%SCRIPTDIR%\sc4pac-cli.jar" %*


### PR DESCRIPTION
This PR adds experimental support for Clickteam installers (see #2) with the [cicdec](https://github.com/Bioruebe/cicdec) tool.

I am a total novice to Scala, so I had to search my way through the code a bit, but I've ended with something that works. I couldn't find a way to pass the type of the asset all the way down to the `WrappedArchive.apply()` method (as proposed in #2), so the solution I went for is to just try 7zip first, and if it fails try `cicdec`.

Currently this requires the `cicdec.exe` to be in the PATH variable, but it could be possible to bundle `cicdec.exe` with the tool as well of course.

I've tested this with the following yaml file:
```yaml
group: aaron-graham
name: gracie-manor
version: 1.0.0
subfolder: 200-residential
info:
  summary: NYBT Gracie Manor - Residential
  author: Aaron Graham
  website: https://community.simtropolis.com/files/file/28981-nybt-gracie-manor/

variants:
  - variant: { nightmode: dark }
    dependencies: ["simfox:day-and-nite-mod"]
    assets:
      - assetId: aaron-graham-gracie-manor-darknite
  - variant: { nightmode: standard }
    assets:
      - assetId: aaron-graham-gracie-manor-maxisnite

---
assetId: aaron-graham-gracie-manor-darknite
version: 1.0.0
lastModified: "2016-10-06T23:02:05Z"
url: https://community.simtropolis.com/files/file/28981-nybt-gracie-manor/?do=download&r=163407
type: clickteam-installer

---
assetId: aaron-graham-gracie-manor-maxisnite
version: 1.0.0
lastModified: "2016-10-06T23:02:05Z"
url: https://community.simtropolis.com/files/file/28981-nybt-gracie-manor/?do=download&r=163406
type: clickteam-installer
```

Known issues:

 - It looks like the `cicdec` tool does not work with filepaths longer than 260 characters. This is a bit problematic because the file paths can get quite long in the cache. I will see if I can find a workaround with using a different temp folder if it is detected that the file path is too long.