### PR TITLE
add support for checksums of assets and DLLs

### DIFF
--- a/channel-testing/json/files/package-bFile.dat
+++ b/channel-testing/json/files/package-bFile.dat
@@ -1,0 +1,1 @@
+DBPF dummy file

--- a/channel-testing/json/metadata/memo/demo-package/1.0/pkg.json
+++ b/channel-testing/json/metadata/memo/demo-package/1.0/pkg.json
@@ -22,7 +22,13 @@
      "assetId": "memo-demo-package-file-b-dat"
     },
     {
-     "assetId": "memo-demo-package-file-b-dll"
+     "assetId": "memo-demo-package-file-b-dll",
+     "withChecksum": [
+      {
+       "include": "package-bFile.dll",
+       "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+     ]
     }
    ]
   }

--- a/channel-testing/json/metadata/sc4pacAsset/memo-demo-package-file-a-zip/1.0/pkg.json
+++ b/channel-testing/json/metadata/sc4pacAsset/memo-demo-package-file-a-zip/1.0/pkg.json
@@ -6,5 +6,8 @@
  "lastModified": "2023-07-29T21:33:56Z",
  "requiredBy": [
   "memo:demo-package"
- ]
+ ],
+ "checksum": {
+  "sha256": "3020ce725261efd11cbf8708f3fe1e655212116ce8e390845114a756af59246b"
+ }
 }

--- a/channel-testing/json/sc4pac-channel-contents.json
+++ b/channel-testing/json/sc4pac-channel-contents.json
@@ -9,7 +9,7 @@
    ],
    "checksums": {
     "1.0": {
-     "sha256": "11344c3743316e628fe9f8ccf5cecd3db26f61b99fe1b9dc6d41562902dda06a"
+     "sha256": "6c7e6f865df0127e21efb37858686c6c810f540b70121ee3047b51ffe66eb55d"
     }
    },
    "category": [
@@ -55,7 +55,7 @@
    ],
    "checksums": {
     "1.0": {
-     "sha256": "21942553157081b75f95e60574497b464043499854c71b952ae468ba0fdef5ff"
+     "sha256": "42d43907c8fe07dcf673429ab0fb7a661bcd4467edd8e024f94420bfbe88550b"
     }
    }
   },

--- a/channel-testing/yaml/memo/demo-package.yaml
+++ b/channel-testing/yaml/memo/demo-package.yaml
@@ -17,6 +17,8 @@ assetId: "memo-demo-package-file-a-zip"
 version: "1.0"
 lastModified: "2023-07-29T21:33:56Z"
 url: "http://localhost:8090/files/package-aFile3.zip"
+checksum:
+  sha256: 3020ce725261efd11cbf8708f3fe1e655212116ce8e390845114a756af59246b
 
 ---
 assetId: "memo-demo-package-file-b-dat"

--- a/channel-testing/yaml/memo/demo-package.yaml
+++ b/channel-testing/yaml/memo/demo-package.yaml
@@ -8,6 +8,9 @@ assets:
 - assetId: "memo-demo-package-file-a-zip"
 - assetId: "memo-demo-package-file-b-dat"
 - assetId: "memo-demo-package-file-b-dll"
+  withChecksum:
+  - include: package-bFile.dll
+    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 ---
 assetId: "memo-demo-package-file-a-zip"

--- a/shared/shared/src/main/scala/sc4pac/shared.scala
+++ b/shared/shared/src/main/scala/sc4pac/shared.scala
@@ -106,8 +106,8 @@ abstract class SharedData {
     url: String,
     lastModified: Instant = null.asInstanceOf[Instant],
     archiveType: Option[ArchiveType] = None,
-    requiredBy: Seq[BareModule] = Seq.empty  // optional and only informative (mangles all variants and versions, is limited to one channel,
-                                             // can easily become outdated since json files are cached indefinitely)
+    requiredBy: Seq[BareModule] = Seq.empty,  // optional and only informative (mangles all variants and versions)
+    checksum: Checksum = emptyChecksum,
   ) extends PackageAsset /*derives ReadWriter*/ {
     def attributes: Map[String, String] = {
       val m = Map(Asset.urlKey -> url)

--- a/shared/shared/src/main/scala/sc4pac/shared.scala
+++ b/shared/shared/src/main/scala/sc4pac/shared.scala
@@ -46,6 +46,9 @@ abstract class SharedData {
   implicit val checksumRw: ReadWriter[Checksum]
   protected def emptyChecksum: Checksum
 
+  type IncludeWithChecksum
+  implicit val includeWithChecksumRw: ReadWriter[IncludeWithChecksum]
+
   implicit val bareModuleRw: ReadWriter[BareModule]
 
   case class Dependency(group: String, name: String, version: String) derives ReadWriter
@@ -53,7 +56,8 @@ abstract class SharedData {
   case class AssetReference(
     assetId: String,
     include: Seq[String] = Seq.empty,
-    exclude: Seq[String] = Seq.empty
+    exclude: Seq[String] = Seq.empty,
+    withChecksum: Seq[IncludeWithChecksum] = Seq.empty,
   ) derives ReadWriter
 
   case class VariantData(

--- a/src/main/scala/sc4pac/ChannelUtil.scala
+++ b/src/main/scala/sc4pac/ChannelUtil.scala
@@ -55,8 +55,10 @@ object ChannelUtil {
     url: String,
     lastModified: java.time.Instant = null,
     archiveType: JD.ArchiveType = null,
+    checksum: JD.Checksum = JD.Checksum.empty,
   ) derives ReadWriter {  // the difference to JD.Asset is that JD.Asset is part of a sealed trait requiring a `$type` field
-    def toAsset = JD.Asset(assetId = assetId, version = version, url = url, lastModified = lastModified, archiveType = Option(archiveType), requiredBy = Nil)
+    def toAsset = JD.Asset(assetId = assetId, version = version, url = url, lastModified = lastModified,
+      archiveType = Option(archiveType), requiredBy = Nil, checksum = checksum)
   }
 
   private def parseCirceJson[A : Reader](j: Json): IO[upickle.core.Abort | IllegalArgumentException, A] = {

--- a/src/main/scala/sc4pac/Constants.scala
+++ b/src/main/scala/sc4pac/Constants.scala
@@ -7,9 +7,8 @@ import scala.concurrent.duration.DurationInt
 
 object Constants {
   export JsonRepoUtil.sc4pacAssetOrg  // val sc4pacAssetOrg = Organization("sc4pacAsset")
-  private val dbpfFileTypeOnly = """(?<=\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4)$"""
-  val defaultInclude = dbpfFileTypeOnly  // includes only plugin files (without dll)
-  val defaultExclude = """(?<!\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4)$"""  // excludes files with other file types
+  val defaultIncludePattern = Pattern.compile("""(?<=\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4)$""", Pattern.CASE_INSENSITIVE)  // includes only plugin files (without dll)
+  val defaultExcludePattern = Pattern.compile("""(?<!\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4)$""", Pattern.CASE_INSENSITIVE)  // excludes files with other file types
   val sc4fileTypePattern = Pattern.compile("""\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4|\.dll$""", Pattern.CASE_INSENSITIVE)
   val versionLatestRelease = "latest.release"
   val defaultChannelUrls = Seq(MetadataRepository.parseChannelUrl("https://memo33.github.io/sc4pac/channel/").toOption.get)

--- a/src/main/scala/sc4pac/Constants.scala
+++ b/src/main/scala/sc4pac/Constants.scala
@@ -7,8 +7,9 @@ import scala.concurrent.duration.DurationInt
 
 object Constants {
   export JsonRepoUtil.sc4pacAssetOrg  // val sc4pacAssetOrg = Organization("sc4pacAsset")
-  val defaultInclude = """(?<=\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4|\.dll)$"""  // includes only plugin files
-  val defaultExclude = """(?<!\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4|\.dll)$"""  // excludes files with other file types
+  private val dbpfFileTypeOnly = """(?<=\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4)$"""
+  val defaultInclude = dbpfFileTypeOnly  // includes only plugin files (without dll)
+  val defaultExclude = """(?<!\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4)$"""  // excludes files with other file types
   val sc4fileTypePattern = Pattern.compile("""\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4|\.dll$""", Pattern.CASE_INSENSITIVE)
   val versionLatestRelease = "latest.release"
   val defaultChannelUrls = Seq(MetadataRepository.parseChannelUrl("https://memo33.github.io/sc4pac/channel/").toOption.get)

--- a/src/main/scala/sc4pac/Constants.scala
+++ b/src/main/scala/sc4pac/Constants.scala
@@ -6,10 +6,7 @@ import java.util.regex.Pattern
 import scala.concurrent.duration.DurationInt
 
 object Constants {
-  val compile = Configuration.compile  // includes only metadata as dependencies
-  val link = new Configuration("link")  // extends `compile` with actual assets (TODO rename to `install`?)
   export JsonRepoUtil.sc4pacAssetOrg  // val sc4pacAssetOrg = Organization("sc4pacAsset")
-  val sc4pacAssetType = Type("sc4pac-resource")  // TODO
   val defaultInclude = """(?<=\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4|\.dll)$"""  // includes only plugin files
   val defaultExclude = """(?<!\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4|\.dll)$"""  // excludes files with other file types
   val sc4fileTypePattern = Pattern.compile("""\.dat|\.sc4model|\.sc4lot|\.sc4desc|\.sc4|\.dll$""", Pattern.CASE_INSENSITIVE)

--- a/src/main/scala/sc4pac/Data.scala
+++ b/src/main/scala/sc4pac/Data.scala
@@ -225,7 +225,7 @@ object JsonData extends SharedData {
       (usedPatternsBuilder, accepts)
     }
 
-    def usedPatternWarnings(usedPatterns: Set[Pattern]): Seq[Warning] = {
+    def usedPatternWarnings(usedPatterns: Set[Pattern], asset: BareAsset): Seq[Warning] = {
       val unused: Seq[Pattern] =
         (include.iterator ++ exclude ++ includeWithChecksum.iterator.map(_._1))
         .filter(p => !usedPatterns.contains(p)).toSeq
@@ -235,7 +235,7 @@ object JsonData extends SharedData {
         Seq(
           "The package metadata seems to be out-of-date, so the package may not have been fully installed. " +
           "Please report this to the maintainers of the package metadata. " +
-          "These inclusion/exclusion patterns did not match any files in the asset: " + unused.mkString(" "))
+          s"These inclusion/exclusion patterns did not match any files in the asset ${asset.assetId.value}: " + unused.mkString(" "))
       }
     }
   }

--- a/src/main/scala/sc4pac/Data.scala
+++ b/src/main/scala/sc4pac/Data.scala
@@ -198,10 +198,10 @@ object JsonData extends SharedData {
   }
 
   case class InstallRecipe(include: Seq[Pattern], exclude: Seq[Pattern]) {
-    def makeAcceptancePredicate(): (Builder[Pattern, Set[Pattern]], os.SubPath => Boolean) = {
+    def makeAcceptancePredicate(): (Builder[Pattern, Set[Pattern]], Extractor.Predicate) = {
       val usedPatternsBuilder = Set.newBuilder[Pattern] += InstallRecipe.defaultExcludePattern  // default exclude pattern is not required to match anything
 
-      val accepts: os.SubPath => Boolean = { path =>
+      val accepts: Extractor.Predicate = { path =>
         val pathString = path.segments.mkString("/", "/", "")  // paths are checked with leading / and with / as separator
         include.find(_.matcher(pathString).find()) match {
           case None => false

--- a/src/main/scala/sc4pac/Data.scala
+++ b/src/main/scala/sc4pac/Data.scala
@@ -274,4 +274,12 @@ object JsonData extends SharedData {
 
   case class CheckFile(filename: Option[String], checksum: Checksum = Checksum.empty) derives ReadWriter
 
+  case class IncludeWithChecksum(include: String, sha256: ArraySeq[Byte])
+
+  implicit val includeWithChecksumRw: ReadWriter[IncludeWithChecksum] =
+    readwriter[Map[String, String]].bimap[IncludeWithChecksum](
+      (data: IncludeWithChecksum) => Map("include" -> data.include, "sha256" -> Checksum.bytesToString(data.sha256)),
+      (m: Map[String, String]) => IncludeWithChecksum(include = m("include"), sha256 = Checksum.stringToBytes(m("sha256"))),
+    )
+
 }

--- a/src/main/scala/sc4pac/Data.scala
+++ b/src/main/scala/sc4pac/Data.scala
@@ -167,7 +167,8 @@ object JsonData extends SharedData {
           version = dep.version,
           url = dep.url,
           lastModified = dep.lastModified.getOrElse(null),
-          archiveType = dep.archiveType
+          archiveType = dep.archiveType,
+          checksum = dep.checksum,
         ))
       )
     }

--- a/src/main/scala/sc4pac/MetadataRepository.scala
+++ b/src/main/scala/sc4pac/MetadataRepository.scala
@@ -142,7 +142,7 @@ private class JsonRepository(
         // `requiredBy` can change, so we redownload them once the checksum stops matching.
         // (For local channels, there's no need to verify checksums as the local
         // channel files are always up-to-date and Downloader .checked files do not exist.)
-        val jsonArtifact = Artifact(remoteUrl, changing = false, checksum = checksum)
+        val jsonArtifact = Artifact(remoteUrl, changing = false, checksum = checksum, redownloadOnChecksumError = true)
 
         fetch(jsonArtifact)
           .flatMap((jsonStr: String) => JsonIo.read[A](jsonStr, errMsg = remoteUrl))

--- a/src/main/scala/sc4pac/Resolution.scala
+++ b/src/main/scala/sc4pac/Resolution.scala
@@ -69,6 +69,7 @@ object Resolution {
     url: String,
     lastModified: Option[java.time.Instant],
     archiveType: Option[JD.ArchiveType],
+    checksum: JD.Checksum,
   ) extends Dep {
     def isSc4pacAsset: Boolean = true
     def toBareDep: BareAsset = BareAsset(assetId)
@@ -76,7 +77,7 @@ object Resolution {
   object DepAsset {
     def fromAsset(asset: JD.Asset): DepAsset =
       DepAsset(assetId = ModuleName(asset.assetId), version = asset.version, url = asset.url,
-        lastModified = Option(asset.lastModified), archiveType = asset.archiveType)
+        lastModified = Option(asset.lastModified), archiveType = asset.archiveType, checksum = asset.checksum)
   }
 
   /** An sc4pac metadata package dependency. */

--- a/src/main/scala/sc4pac/ResolutionContext.scala
+++ b/src/main/scala/sc4pac/ResolutionContext.scala
@@ -11,28 +11,6 @@ class ResolutionContext(
 ) {
 
   object coursierApi {
-    // val resolve = coursier.Resolve(cache)
-    //   .withRepositories(repositories)
-    //   // .mapResolutionParams(_.addProperties(properties: _*))
-
-    // val fetch = Fetch(cache)
-    //   .withArtifactTypes(Sc4pac.assetTypes)
-    //   // .withArtifactTypes(Set(Type.all))
-    //   .withResolve(resolve)
-    //   .transformResolution(_.flatMap(resolution => deleteStaleCachedFiles(resolution).map(_ => resolution)))
-    //   // .mapResolutionParams(_.withDefaultConfiguration(Constants.link))
-
-    // // To go from an existing resolution (i.e. without resolve) to fetching artifacts,
-    // // one can use (but don't forget to transform the resolution!):
-    // val artifacts = coursier.Artifacts(cache)
-    //   .withArtifactTypes(Sc4pac.assetTypes)
-    //   // .withResolution(resolution)
-    //   // .run() or .runResult()
-
-    // val versions = coursier.Versions(cache).withRepositories(repositories)
-    //   // .withModule(coursier.parse.ModuleParser.module("memo:package-d", "").getOrElse(???))
-    //   // .run()
-
     // merges available versions from different repositories
     private def mergeVersions(versions: Vector[coursier.core.Versions]): coursier.core.Versions = {
       if (versions.isEmpty)

--- a/src/main/scala/sc4pac/Sc4pac.scala
+++ b/src/main/scala/sc4pac/Sc4pac.scala
@@ -198,7 +198,7 @@ trait UpdateService { this: Sc4pac =>
               hints = depAsset.archiveType,
               stagingRoot)
           // TODO catch IOExceptions
-          regexWarnings ++ recipe.usedPatternWarnings(usedPatterns)
+          regexWarnings ++ recipe.usedPatternWarnings(usedPatterns, id)
       }
     }
 

--- a/src/main/scala/sc4pac/Sc4pac.scala
+++ b/src/main/scala/sc4pac/Sc4pac.scala
@@ -439,7 +439,6 @@ trait UpdateService { this: Sc4pac =>
 
 
 object Sc4pac {
-  val assetTypes = Set(Constants.sc4pacAssetType)
 
   case class UpdatePlan(toInstall: Set[Dep], toReinstall: Set[Dep], toRemove: Set[Dep]) {
     def isUpToDate: Boolean = toRemove.isEmpty && toReinstall.isEmpty && toInstall.isEmpty

--- a/src/main/scala/sc4pac/error.scala
+++ b/src/main/scala/sc4pac/error.scala
@@ -28,6 +28,8 @@ final class DownloadFailed(val title: String, val detail: String) extends java.i
 
 final class ChecksumError(val title: String, val detail: String) extends java.io.IOException(s"$title $detail") with Sc4pacErr
 
+final class NotADbpfFile(val title: String, val detail: String) extends java.io.IOException(s"$title $detail") with Sc4pacErr
+
 final class NoChannelsAvailable(val title: String, val detail: String) extends java.io.IOException(s"$title $detail") with Sc4pacErr
 
 final class SymlinkCreationFailed(msg: String) extends java.io.IOException(msg) with Sc4pacErr

--- a/src/main/scala/sc4pac/extractor.scala
+++ b/src/main/scala/sc4pac/extractor.scala
@@ -145,7 +145,7 @@ object Extractor {
           if (isDirectory(entry)) {
             None
           } else {
-            val validatorOpt = predicate(path)  // TODO in case of WrappedNonarchive, validate against archive checksum instead of IncludeWithChecksum
+            val validatorOpt = predicate(path)
             logger.extractingArchiveEntry(path, validatorOpt.isDefined)
             validatorOpt.map((entry, path, _))
           }

--- a/src/main/scala/sc4pac/extractor.scala
+++ b/src/main/scala/sc4pac/extractor.scala
@@ -358,7 +358,13 @@ object Extractor {
   }
 
   object DbpfValidator extends Validator {
-    private def isDbpf(path: os.Path): Boolean = true  // ??? TODO
+    private val dbpfSignature = Array[Byte]('D', 'B', 'P', 'F')
+
+    private def isDbpf(path: os.Path): Boolean = {
+      val signature = os.read.bytes(path, offset = 0, count = 4)
+      signature.sameElements(dbpfSignature)
+    }
+
     def validate(path: os.Path): Unit = {
       if (!isDbpf(path))
         throw NotADbpfFile("Extracted file is not a DBPF file. " +

--- a/src/main/scala/sc4pac/package.scala
+++ b/src/main/scala/sc4pac/package.scala
@@ -67,11 +67,12 @@ package object sc4pac {
 
   class ProfileRoot(val path: os.Path)
 
-  case class Artifact(
-    url: String,
-    changing: Boolean = false,  // if true, redownload local artifact after exceeding time-to-live (ttl)
-    lastModified: Option[java.time.Instant] = None,  // redownload local artifact if older than that
-    checksum: JsonData.Checksum = JsonData.Checksum.empty,  // redownload local artifact if remote checksum does not match anymore
+  class Artifact(
+    val url: String,
+    val changing: Boolean = false,  // if true, redownload local artifact after exceeding time-to-live (ttl)
+    val lastModified: Option[java.time.Instant] = None,  // redownload local artifact if older than that
+    val checksum: JsonData.Checksum = JsonData.Checksum.empty,  // redownload local artifact if remote checksum does not match anymore
+    val redownloadOnChecksumError: Boolean = true,  // otherwise fail
   )
 
 }

--- a/src/test/scala/sc4pac/ExtractorSpec.scala
+++ b/src/test/scala/sc4pac/ExtractorSpec.scala
@@ -56,25 +56,25 @@ class ExtractorSpec extends AnyWordSpec with Matchers {
 
   def createSampleFiles(in: os.Path): Seq[os.Path] = {
     val files = Seq(
-      in / "common" / "prefix" / "a.SC4Model",
-      in / "common" / "prefix" / "b" / "dollars$$ and spaces.SC4Lot",
-      in / "common" / "prefix" / "c" / "c" / "c.SC4Lot",
-      in / "common" / "prefix" / "c" / "d" / "d.SC4Lot",
-      in / "common" / "prefix" / "c" / "e.SC4Model",
-      in / "common" / "prefix" / "c" / "f.SC4Desc",
-      in / "common" / "prefix" / "c" / "g.dat",
-      in / "common" / "prefix" / "c" / "h.dll",
+      in / "common" / "prefix" / "a.SC4Model" -> "DBPF dummy",
+      in / "common" / "prefix" / "b" / "dollars$$ and spaces.SC4Lot" -> "DBPF dummy",
+      in / "common" / "prefix" / "c" / "c" / "c.SC4Lot" -> "DBPF dummy",
+      in / "common" / "prefix" / "c" / "d" / "d.SC4Lot" -> "DBPF dummy",
+      in / "common" / "prefix" / "c" / "e.SC4Model" -> "DBPF dummy",
+      in / "common" / "prefix" / "c" / "f.SC4Desc" -> "DBPF dummy",
+      in / "common" / "prefix" / "c" / "g.dat" -> "DBPF dummy",
+      in / "common" / "prefix" / "c" / "h.dll" -> "MZ dll dummy",
     )
     val ignoredFiles = Seq(
-      in / "readme.txt",
-      in / "common" / "readme.md",
-      in / "common" / "prefix" / "license",
+      in / "readme.txt" -> "dummy",
+      in / "common" / "readme.md" -> "dummy",
+      in / "common" / "prefix" / "license" -> "dummy",
     )
-    for (f <- (files ++ ignoredFiles)) {
+    for ((f, content) <- (files ++ ignoredFiles)) {
       os.makeDir.all(f / os.up)
-      os.write(f, "dummy")
+      os.write(f, content)
     }
-    files
+    files.map(_._1)
   }
 
   def withSampleFiles(testCode: (os.Path, os.Path, Seq[os.Path]) => Any): Any = withTempDir { (tmpDir) =>
@@ -84,8 +84,10 @@ class ExtractorSpec extends AnyWordSpec with Matchers {
     testCode(in, out, files)
   }
 
+  val assetRef = JD.AssetReference("dummy", withChecksum = Seq(JD.IncludeWithChecksum("h.dll", JD.Checksum.stringToBytes("07a3036cfb4e1705969b4fa8ccf5e28eac0fa6df598b81e020592d6a6041a9fd"))))
+
   def createPredicate() = {
-    val (recipe, warnings) = JD.InstallRecipe.fromAssetReference(JD.AssetReference("dummy"))
+    val (recipe, warnings) = JD.InstallRecipe.fromAssetReference(assetRef)
     val (usedPatternsBuilder, predicate) = recipe.makeAcceptancePredicate()
     predicate
   }
@@ -150,7 +152,7 @@ class ExtractorSpec extends AnyWordSpec with Matchers {
         val jarsDir = in / os.up / "jars"
         os.makeDir.all(jarsDir)
 
-        val recipe = JD.InstallRecipe.fromAssetReference(JD.AssetReference("dummy"))._1
+        val recipe = JD.InstallRecipe.fromAssetReference(assetRef)._1
         Extractor(CliLogger())
           .extract(archiveFile.toIO, fallbackFilename = None, out, recipe, Some(Extractor.JarExtraction(jarsDir)), hints = None, stagingRoot = out)
 
@@ -172,7 +174,7 @@ class ExtractorSpec extends AnyWordSpec with Matchers {
       val jarsDir = in / os.up / "jars"
       os.makeDir.all(jarsDir)
 
-      val recipe = JD.InstallRecipe.fromAssetReference(JD.AssetReference("dummy"))._1
+      val recipe = JD.InstallRecipe.fromAssetReference(assetRef)._1
       Extractor(CliLogger())
         .extract(archiveFile.toIO, fallbackFilename = None, out, recipe, Some(Extractor.JarExtraction(jarsDir)), hints = None, stagingRoot = out)
 

--- a/web/src/main/scala/sc4pac/web/ChannelPage.scala
+++ b/web/src/main/scala/sc4pac/web/ChannelPage.scala
@@ -24,6 +24,8 @@ object JsonData extends SharedData {
   opaque type Checksum = Map[String, String]
   val checksumRw = UP.readwriter[Map[String, String]]
   protected def emptyChecksum = Map.empty
+  opaque type IncludeWithChecksum = Map[String, String]
+  val includeWithChecksumRw = UP.readwriter[Map[String, String]]
 
   private val regexModule = """([^:\s]+):([^:\s]+)""".r
   def parseModule(pkgName: String): Either[String, BareModule] =


### PR DESCRIPTION
This adds:

1. an _optional_ `checksum: { sha256: "…" }` field for metadata of assets. This is verified after download, before extraction of the archive.

2. a _mandatory_ checksum for including a DLL in the extraction. This is verified after extraction, before copying extracted files into the plugins folder.

```yaml
- assetId: some-asset
  include:
  - some.dat
  withChecksum:
  - include: some.dll
    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```

All extracted files without checksum must be DBPF files now. This is ensured by checking the binary file signature.

Resolves #13.