### PR TITLE
fix copying of symlinks on Windows

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -24,5 +24,10 @@ jobs:
     - uses: sbt/setup-sbt@v1
     - name: Build
       run: make dist && ./sc4pac --version && sha256sum target/dist/sc4pac*.zip
+    - uses: actions/upload-artifact@v4
+      with:
+        name: sc4pac-cli-artifact
+        path: target/dist/sc4pac*.zip
+        retention-days: 7
     - name: Test
       run: sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,12 @@ libraryDependencies += "org.slf4j" % "slf4j-nop" % "2.0.7"  // ignore logging in
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % Test exclude("org.scala-lang.modules", "scala-xml_3")
 
+libraryDependencies ++= Seq(
+  "dev.zio" %% "zio-test"          % "2.1.14" % Test,
+  "dev.zio" %% "zio-test-sbt"      % "2.1.14" % Test,
+  "dev.zio" %% "zio-test-magnolia" % "2.1.14" % Test,
+)
+
 
 lazy val shared = (crossProject(JSPlatform, JVMPlatform) in file("shared"))
   .settings(

--- a/src/main/scala/sc4pac/api/api.scala
+++ b/src/main/scala/sc4pac/api/api.scala
@@ -48,6 +48,7 @@ class Api(options: sc4pac.cli.Commands.ServerOptions) {
     case abort: error.ChecksumError => ErrorMessage.DownloadFailed(abort.title, abort.detail)
     case abort: error.ChannelsNotAvailable => ErrorMessage.ChannelsNotAvailable(abort.title, abort.detail)
     case abort: error.ReadingProfileFailed => ErrorMessage.ReadingProfileFailed(abort.title, abort.detail)
+    case abort: error.Sc4pacPublishIncomplete => ErrorMessage.PublishedFilesIncomplete(abort.title, abort.detail)
     case abort: error.Sc4pacAbort => ErrorMessage.Aborted("Operation aborted.", "")
     case abort: java.nio.file.AccessDeniedException => ErrorMessage.FileAccessDenied(
       "File access denied. Check that you have permissions to access the file or directory.", abort.getMessage)
@@ -62,6 +63,7 @@ class Api(options: sc4pac.cli.Commands.ServerOptions) {
     case abort: error.ChecksumError => Status.BadGateway
     case abort: error.ChannelsNotAvailable => Status.BadGateway
     case abort: error.ReadingProfileFailed => Status.InternalServerError
+    case abort: error.Sc4pacPublishIncomplete => Status.InternalServerError
     case abort: error.Sc4pacAbort => Status.Ok  // this is not really an error, but the expected control flow
     case abort: java.nio.file.AccessDeniedException => Status.InternalServerError
   }

--- a/src/main/scala/sc4pac/api/message.scala
+++ b/src/main/scala/sc4pac/api/message.scala
@@ -119,6 +119,8 @@ object ErrorMessage {
   case class InitNotAllowed(title: String, detail: String) extends ErrorMessage derives UP.ReadWriter
   @upickle.implicits.key("/error/file-access-denied")
   case class FileAccessDenied(title: String, detail: String) extends ErrorMessage derives UP.ReadWriter
+  @upickle.implicits.key("/error/published-files-incomplete")
+  case class PublishedFilesIncomplete(title: String, detail: String) extends ErrorMessage derives UP.ReadWriter
 }
 
 @upickle.implicits.key("/result")

--- a/src/main/scala/sc4pac/cli.scala
+++ b/src/main/scala/sc4pac/cli.scala
@@ -43,11 +43,13 @@ object Commands {
   type ExpectedFailure = error.Sc4pacAbort | error.DownloadFailed | error.ChannelsNotAvailable
     | error.Sc4pacVersionNotFound | error.Sc4pacAssetNotFound | error.ExtractionFailed
     | error.UnsatisfiableVariantConstraints | error.ChecksumError | error.ReadingProfileFailed
+    | error.Sc4pacPublishIncomplete
     | java.nio.file.AccessDeniedException
 
   private def handleExpectedFailures(abort: ExpectedFailure, exit: Int => Nothing): Nothing = abort match {
     case abort: error.Sc4pacAbort => { System.err.println("Operation aborted."); exit(1) }
-    case abort: java.nio.file.AccessDeniedException => { System.err.println(s"Operation.aborted. File access denied. Check your permissions to access the file or directory: ${abort.getMessage}"); exit(ExitCodes.AccessDenied) }  // any command that creates directories or files
+    case abort: java.nio.file.AccessDeniedException => { System.err.println(s"Operation aborted. File access denied. Check your permissions to access the file or directory: ${abort.getMessage}"); exit(ExitCodes.AccessDenied) }  // any command that creates directories or files
+    case abort: error.Sc4pacPublishIncomplete => { System.err.println(s"Operation finished with warnings. ${abort.getMessage}"); exit(ExitCodes.PublishIncomplete) }  // update (final step)
     case abort => { System.err.println(s"Operation aborted. ${abort.getMessage}"); exit(1) }
   }
 
@@ -55,6 +57,7 @@ object Commands {
     val JavaNotFound = 55  // see `sc4pac` and `sc4pac.bat` scripts
     val PortOccupied = 56
     val AccessDenied = 57
+    val PublishIncomplete = 58
   }
 
   private def runMainExit(task: Task[Unit], exit: Int => Nothing): Nothing = {

--- a/src/main/scala/sc4pac/error.scala
+++ b/src/main/scala/sc4pac/error.scala
@@ -12,7 +12,7 @@ final class Sc4pacTimeout(msg: String) extends java.io.IOException(msg) with Sc4
 
 final class Sc4pacNotInteractive(msg: String) extends java.io.IOException(msg) with Sc4pacErr
 
-final class Sc4pacPublishWarning(msg: String) extends java.io.IOException(msg) with Sc4pacErr
+final class Sc4pacPublishIncomplete(val title: String, val detail: String) extends java.io.IOException(s"$title $detail") with Sc4pacErr
 
 final class Sc4pacAssetNotFound(val title: String, val detail: String) extends java.io.IOException(s"$title $detail") with Sc4pacErr
 

--- a/src/test/scala/sc4pac/ApiSpecZIO.scala
+++ b/src/test/scala/sc4pac/ApiSpecZIO.scala
@@ -1,0 +1,602 @@
+package io.github.memo33
+package sc4pac
+
+import zio.*
+import zio.test.*
+import zio.http.{Client, Body, URL, Response, Request, Handler, ChannelEvent, WebSocketFrame}
+import upickle.default as UP
+import ujson.Obj
+
+import JsonData as JD
+import cli.Commands.ServerOptions
+import sc4pac.test.FileServer
+
+object ApiSpecZIO extends ZIOSpecDefault {
+
+  /** Creates a temporary profiles directory which is removed when the Scope is closed. */
+  val profilesDirLayer: ZLayer[Any, Throwable, ProfilesDir] =
+    ZLayer.scoped(
+      ZIO.acquireRelease(ZIO.attemptBlockingIO {
+        ProfilesDir(os.temp.dir(os.pwd / "target", prefix = "test-tmp"))
+      })(profilesDir => ZIO.attemptBlockingIO {
+        os.remove.all(profilesDir.path)
+      }.orDie)
+    )
+
+  /** Launches an API server for the duration of the Scope. */
+  val serverLayer: zio.ZLayer[ProfilesDir, Throwable, ServerOptions] =
+    zio.ZLayer.scoped(
+      for {
+        profilesDir  <- ZIO.serviceWith[ProfilesDir](_.path)
+        options      =  ServerOptions(
+                          port = scala.util.Random.between(50000, 60000),
+                          profilesDir = profilesDir.toString,
+                          autoShutdown = false,
+                          indent = 1,
+                        )
+        fiber        <- cli.Commands.Server.serve(options, profilesDir = profilesDir, webAppDir = None)
+        _            <- ZIO.addFinalizerExit(exitVal => ZIO.succeed {
+                          println(s"...Sc4pac server on port ${options.port} has been shut down: $exitVal")
+                        })
+      } yield options
+    )
+
+  val fileServerLayer: ZLayer[Any, Nothing, FileServer] =
+    FileServer.serve(os.pwd / "channel-testing" / "json", port = 8090)  // TODO port is hardcoded in ./channel-testing/ files
+
+  val setFileServerChannel: ZIO[FileServer & JD.Profile & ServerOptions & Client, Throwable, Unit] =
+    for {
+      port      <- ZIO.serviceWith[FileServer](_.port)
+      profileId <- ZIO.serviceWith[JD.Profile](_.id)
+      resp      <- postEndpoint(s"channels.set?profile=$profileId", jsonBody(Seq(s"http://localhost:$port/")))
+      _         <- ZIO.whenDiscard(resp.status.code != 200)(ZIO.fail(AssertionError(s"/channels.set responded with ${resp.status.code}")))
+    } yield ()
+
+  val currentProfileLayer: zio.ZLayer[ServerOptions & Client, Throwable, JD.Profile] =
+    ZLayer(
+      for {
+        profilesList <- getEndpoint("profiles.list").flatMap(resp => parseBody[api.ProfilesList](resp.body))
+        id <- ZIO.getOrFail(profilesList.currentProfileId)
+        profile <- ZIO.getOrFail(profilesList.profiles.find(_.id == id))
+      } yield profile
+    )
+
+  def withTestResultRef[R](test: RIO[R & Ref[TestResult], Unit]): RIO[R, TestResult] = {
+    val emptyTestResultRefLayer: ZLayer[Any, Nothing, Ref[TestResult]] = ZLayer(Ref.make(TestResult.allSuccesses(Nil)))
+    test.foldZIO(
+      // In case of exception, check if preliminary assertions already failed.
+      // If so, return the partial test result ("fail early"), as the output is
+      // likely more useful than the err.
+      failure = (err: Throwable) =>
+        ZIO.serviceWithZIO[Ref[TestResult]](_.get).flatMap(partialResult =>
+          if (partialResult.isFailure) ZIO.succeed(partialResult) else ZIO.fail(err)
+        ),
+      success = (_: Unit) => ZIO.serviceWithZIO[Ref[TestResult]](_.get),
+    ).provideSomeLayer(emptyTestResultRefLayer)
+  }
+
+  /** Adds an assert to the mutable reference */
+  def addTestResult(assert: TestResult): ZIO[Ref[TestResult], Nothing, Unit] =
+    ZIO.serviceWithZIO[Ref[TestResult]](_.update(_ && assert))
+
+  def jsonBody[A : UP.Writer](data: A): Body =
+    Body.fromChunk(zio.Chunk.fromArray(UP.writeToByteArray(data)), zio.http.MediaType.application.json)
+
+  def parseBody[A : UP.Reader](body: Body) = body.asArray.flatMap(bytes => ZIO.attempt { UP.read[A](bytes) })
+
+  // Asserts that response is 200 (stored in Ref) and parses the body. */
+  def getBody200[A : UP.Reader](response: Response): RIO[Ref[TestResult], A] =
+    for {
+      _    <- addTestResult(assertTrue(response.status.code == 200))
+      data <- parseBody[A](response.body)
+    } yield data
+
+  def isOk200(response: Response): RIO[Ref[TestResult], Unit] =
+    for {
+      data <- getBody200[ujson.Value](response)
+      _    <- addTestResult(assertTrue(data == jsonOk))
+    } yield ()
+
+  def endpoint(path: String): RIO[ServerOptions, URL] =
+    ZIO.serviceWith[ServerOptions](options => URL.empty.absolute(zio.http.Scheme.HTTP, "localhost", options.port) / path)
+
+  def postEndpoint(path: String, body: Body): RIO[ServerOptions & Client, Response] =
+    for {
+      url <- endpoint(path)
+      resp <- Client.batched(Request.post(url, body))
+    } yield resp
+
+  def getEndpoint(path: String): RIO[ServerOptions & Client, Response] =
+    for {
+      url <- endpoint(path)
+      resp <- Client.batched(Request.get(url))
+    } yield resp
+
+  val jsonOk = Obj("$type" -> "/result", "ok" -> true)
+
+  // def makeChannel(packages: Seq[JD.PackageAsset]) =
+  //   for {
+  //     channel <- YamlChannelBuilder().result(packages).provideSomeLayer(ZLayer.succeed(JD.Channel.Info(channelLabel = Some("Test-Channel"), metadataSourceUrl = None)))
+  //   } yield channel
+
+  val removeAll: RIO[JD.Profile & ServerOptions & Client, Unit] =
+    for {
+      id   <- ZIO.serviceWith[JD.Profile](_.id)
+      resp <- getEndpoint(s"plugins.added.list?profile=$id")
+      pkgs <- parseBody[Seq[String]](resp.body)
+      resp <- postEndpoint(s"plugins.remove?profile=$id", jsonBody(pkgs))
+      _    <- ZIO.whenDiscard(resp.status.code != 200)(ZIO.fail(AssertionError(s"/plugins.remove responded with ${resp.status.code}")))
+    } yield ()
+
+  class MsgFrame(val msg: api.Message, val json: ujson.Value)
+
+  /** Calls a websocket endpoint, allowing to verify messages against
+    * expectations:
+    * - `respond`: handle prompt messages with desired responses
+    * - `filter`: ignore some messages before passing them to `checkMessages`
+    * - `checkMessages`: an effect to verify all the messages after filtering satisfy expectations.
+    *
+    * If this hangs, then `checkMessages` might wait for taking too many messages from the queue.
+    */
+  def wsEndpoint(
+    path: String,
+    respond: PartialFunction[api.PromptMessage, RIO[Ref[TestResult], api.ResponseMessage]],
+    filter: MsgFrame => Boolean = _ => true,
+    checkMessages: Queue[MsgFrame] => ZIO[Scope & Ref[TestResult], Throwable, Unit] = _ => ZIO.unit,
+  ): ZIO[ServerOptions & Client & Ref[TestResult] & Scope, Throwable, Response] =
+    for {
+      url      <- endpoint(path).map(_.scheme(zio.http.Scheme.WS))
+      promise  <- Promise.make[Throwable, Unit]  // abnormal exit of websocket channel
+      queue    <- Queue.unbounded[MsgFrame]
+      // _        <- ZIO.addFinalizerExit(exitVal => ZIO.succeed(println(s"websocket: scope closed: $exitVal")))
+      resp     <- Handler.webSocket { channel =>
+                    channel.receiveAll {
+                      case ChannelEvent.Read(WebSocketFrame.Text(text)) =>
+                        for {
+                          json <- JsonIo.read[ujson.Value](text)
+                          msg  <- JsonIo.read[api.Message](text)
+                          frame = MsgFrame(msg, json)
+                          _    <- ZIO.whenDiscard(filter(frame))(queue.offer(frame))
+                          _    <- msg match {
+                                    case msg: api.PromptMessage =>
+                                      if (respond.isDefinedAt(msg)) {
+                                        respond(msg).flatMap { response =>
+                                          channel.send(ChannelEvent.Read(WebSocketFrame.Text(UP.write(response))))
+                                        }
+                                      } else {
+                                        val errMsg = s"Partial function `respond` is not defined for prompt message: $msg"
+                                        Console.printLine(errMsg).zipRight(ZIO.fail(AssertionError(errMsg)))
+                                      }
+                                    case _ => ZIO.unit
+                                  }
+                        } yield ()
+                      case event => ZIO.unit  // Console.printLine(s"websocket: unexpected event: $event")
+                    }.zipRight(channel.shutdown)
+                      .onExit {
+                        case zio.Exit.Failure(cause) => promise.failCause(cause)
+                        case zio.Exit.Success(_) => promise.succeed(())
+                      }
+                  }.connect(url, zio.http.Headers.empty)
+      _        <- addTestResult(assertTrue(resp.status.code == 101))  // switching protocol: upgrade to websocket
+      _        <- promise.await.raceWith(checkMessages(queue))(
+                    leftDone = (exitVal, fiberRight) => exitVal match {
+                      case Exit.Success(_) =>
+                        fiberRight.await.timeoutFail
+                          (AssertionError("Timeout in checkMessages: possibly waiting for too many websocket messages"))
+                          (5.seconds)
+                        .zipLeft(fiberRight.interrupt)
+                      case Exit.Failure(cause) => fiberRight.interrupt.zipRight(ZIO.refailCause(cause))
+                    },
+                    rightDone = (exitVal, fiberLeft) => exitVal match {
+                      case Exit.Success(_) =>
+                        fiberLeft.await.timeoutFail
+                          (AssertionError("Timeout in websocket respond: possibly not answering some websocket prompt messages"))
+                          (5.seconds)
+                        .zipRight(fiberLeft.interrupt)
+                      case Exit.Failure(cause) => fiberLeft.interrupt.zipRight(ZIO.refailCause(cause))
+                    },
+                  ).zipRight(queue.shutdown)
+    } yield resp
+
+  def spec = suite("ApiSpecZIO")(
+    test("/server.status") {
+      for {
+        resp <- getEndpoint("server.status")
+        data <- parseBody[api.ServerStatus](resp.body)
+      } yield assertTrue(resp.status.code == 200, data.sc4pacVersion == cli.BuildInfo.version)
+    },
+
+    suite("settings") {
+      Chunk(
+        test("/settings.all.get") {
+          for {
+            resp <- getEndpoint("settings.all.get")
+            data <- parseBody[ujson.Value](resp.body)
+          } yield assertTrue(resp.status.code == 200, data == Obj())
+        },
+        test("/settings.all.set") {
+          val dummySettings = Obj("a" -> 1, "b" -> Obj("c" -> 3, "d" -> Seq(4, 5)))
+          withTestResultRef(for {
+            _    <- postEndpoint("settings.all.set", jsonBody(dummySettings)).flatMap(isOk200)
+            data <- getEndpoint("settings.all.get").flatMap(getBody200[ujson.Value])
+            _    <- addTestResult(assertTrue(data == dummySettings))
+          } yield ())
+        },
+      )
+    },
+
+    suite("profiles")(
+      test("/profiles.list") {
+        for {
+          resp <- getEndpoint("profiles.list")
+          data <- parseBody[api.ProfilesList](resp.body)
+          profilesDir <- ZIO.service[ProfilesDir]
+        } yield assertTrue(
+          resp.status.code == 200,
+          data.profiles.isEmpty,
+          data.currentProfileId == None,
+          data.profilesDir == profilesDir.path.toNIO,
+        )
+      },
+      test("/profiles.add") {
+        val name = s"Test-Profile 🐛 ${scala.util.Random.between(1000, 10000)}"
+        withTestResultRef(for {
+          profile  <- postEndpoint("profiles.add", jsonBody(Obj("name"-> name))).flatMap(getBody200[JD.Profile])
+          _        <- addTestResult(assertTrue(profile.id == "1", profile.name == name))
+          data     <- getEndpoint("profiles.list").flatMap(getBody200[api.ProfilesList])
+          _        <- addTestResult(assertTrue(data.profiles == Seq(profile), data.currentProfileId.is(_.some) == profile.id))
+          profile2 <- postEndpoint("profiles.add", jsonBody(Obj("name"-> s"$name~"))).flatMap(getBody200[JD.Profile])
+          _        <- addTestResult(assertTrue(profile2.id == "2", profile2.name == s"$name~"))
+          data     <- getEndpoint("profiles.list").flatMap(getBody200[api.ProfilesList])
+          _        <- addTestResult(assertTrue(data.profiles == Seq(profile, profile2), data.currentProfileId.is(_.some) == profile2.id))
+        } yield ())
+      },
+      test("/profiles.switch") {
+        withTestResultRef(for {
+          data   <- getEndpoint("profiles.list").flatMap(getBody200[api.ProfilesList])
+          _      <- addTestResult(assertTrue(
+                      data.profiles.exists(_.id == "1"),
+                      !data.profiles.exists(_.id == "42"),
+                      data.currentProfileId.is(_.some) != "1",
+                    ))
+          resp   <- postEndpoint("profiles.switch", jsonBody(Obj("id" -> "42")))
+          _      <- addTestResult(assertTrue(resp.status.code == 400))
+          data2  <- getEndpoint("profiles.list").flatMap(getBody200[api.ProfilesList])
+          _      <- addTestResult(assertTrue(data2 == data))
+          _      <- postEndpoint("profiles.switch", jsonBody(Obj("id" -> "1"))).flatMap(isOk200)
+          data   <- getEndpoint("profiles.list").flatMap(getBody200[api.ProfilesList])
+          _      <- addTestResult(assertTrue(data.currentProfileId.is(_.some) == "1"))
+        } yield ())
+      },
+    ),
+
+    suite("profile")(ZIO.serviceWith[JD.Profile](_.id).map { (profileId: String) =>
+      Chunk(
+        test("/profile.read") {
+          withTestResultRef(for {
+            resp   <- getEndpoint(s"profile.read?profile=$profileId")
+            _      <- addTestResult(assertTrue(resp.status.code == 409))  // not initialized
+            data   <- parseBody[api.ErrorMessage.ProfileNotInitialized](resp.body)
+            _      <- addTestResult(assertTrue(data.platformDefaults.contains("plugins"), data.platformDefaults.contains("cache"), data.platformDefaults.contains("temp")))
+          } yield ())
+        },
+        test("/profile.init") {
+          withTestResultRef(for {
+            config <- ZIO.serviceWith[ServerOptions](options => Obj(
+                        "plugins" -> (os.Path(options.profilesDir) / profileId / "plugins").toString,
+                        "cache" -> (os.Path(options.profilesDir) / profileId / "cache").toString,
+                        "temp" -> "../temp",
+                      ))
+            data   <- postEndpoint(s"profile.init?profile=$profileId", jsonBody(config)).flatMap(getBody200[ujson.Value])
+            _      <- addTestResult(assertTrue(data == Obj(
+                        "pluginsRoot" -> "plugins", "cacheRoot" -> "cache", "tempRoot" -> "../temp",  // relative paths only when inside profiles directory
+                        "variant" -> Obj(), "channels" -> Constants.defaultChannelUrls.map(_.toString),
+                      )))
+            resp   <- postEndpoint(s"profile.init?profile=$profileId", jsonBody(config))
+            _      <- addTestResult(assertTrue(resp.status.code == 409))  // already initialized
+            data2  <- getEndpoint(s"profile.read?profile=$profileId").flatMap(getBody200[ujson.Value])
+            _      <- addTestResult(assertTrue(data2 == data))
+          } yield ())
+        },
+
+        suite("channels")(
+          test("/channels.list") {
+            withTestResultRef(for {
+              data <- getEndpoint(s"channels.list?profile=$profileId").flatMap(getBody200[Seq[String]])
+              _    <- addTestResult(assertTrue(data == Constants.defaultChannelUrls.map(_.toString)))
+            } yield ())
+          },
+          test("/channels.set") {
+            val dummyChannels = Seq(
+              "https://example.org/channel1",  // trailing slash is added
+              "https://example.org/channel2/",
+              "https://example.org/channel3.yaml",
+              "https://example.org/channel3.yaml",  // duplicates are removed
+              "file:///local/channel4/",
+              "file:///C:/local/channel5.yaml",
+            )
+            withTestResultRef(for {
+              resp <- postEndpoint(s"channels.set?profile=$profileId", jsonBody(Seq(":::")))
+              _    <- addTestResult(assertTrue(resp.status.code == 400))
+              _    <- postEndpoint(s"channels.set?profile=$profileId", jsonBody(dummyChannels)).flatMap(isOk200)
+              data <- getEndpoint(s"channels.list?profile=$profileId").flatMap(getBody200[Seq[String]])
+              _    <- addTestResult(assertTrue(data == dummyChannels.updated(0, s"${dummyChannels(0)}/").distinct))
+              _    <- postEndpoint(s"channels.set?profile=$profileId", jsonBody(Seq.empty[String])).flatMap(isOk200)
+              data <- getEndpoint(s"channels.list?profile=$profileId").flatMap(getBody200[Seq[String]])
+              _    <- addTestResult(assertTrue(data == Constants.defaultChannelUrls.map(_.toString)))
+            } yield ())
+          },
+          test("/channels.stats") {
+            withTestResultRef[FileServer & JD.Profile & ServerOptions & Client](for {
+              _    <- setFileServerChannel
+              data <- getEndpoint(s"channels.stats?profile=$profileId").flatMap(getBody200[api.ChannelStatsAll])
+              _    <- addTestResult(assertTrue(
+                        data.combined.totalPackageCount == 3,
+                        data.channels.length == 1,
+                        data.channels(0).url.startsWith("http://localhost:"),
+                      ))
+            } yield ())
+          },
+        ),
+
+        suite("plugins")(
+          test("/plugins.added.list") {
+            withTestResultRef(for {
+              data <- getEndpoint(s"plugins.added.list?profile=$profileId").flatMap(getBody200[Seq[String]])
+              _    <- addTestResult(assertTrue(data == Seq.empty[String]))
+            } yield ())
+          },
+          test("/plugins.add") {
+            withTestResultRef(for {
+              _    <- postEndpoint(s"plugins.add?profile=$profileId", jsonBody(Seq("memo:demo-package"))).flatMap(isOk200)
+              _    <- postEndpoint(s"plugins.add?profile=$profileId", jsonBody(Seq("memo:demo-package"))).flatMap(isOk200)  // idempotent
+              data <- getEndpoint(s"plugins.added.list?profile=$profileId").flatMap(getBody200[Seq[String]])
+              _    <- addTestResult(assertTrue(data == Seq("memo:demo-package")))
+            } yield ())
+          },
+          test("/plugins.remove") {
+            withTestResultRef(for {
+              orig <- getEndpoint(s"plugins.added.list?profile=$profileId").flatMap(getBody200[Seq[String]])
+              _    <- postEndpoint(s"plugins.add?profile=$profileId", jsonBody(Seq("test:nonexistent"))).flatMap(isOk200)
+              data <- getEndpoint(s"plugins.added.list?profile=$profileId").flatMap(getBody200[Seq[String]])
+              _    <- addTestResult(assertTrue(data == orig ++ Seq("test:nonexistent")))
+              _    <- postEndpoint(s"plugins.remove?profile=$profileId", jsonBody(Seq("test:nonexistent"))).flatMap(isOk200)
+              data <- getEndpoint(s"plugins.added.list?profile=$profileId").flatMap(getBody200[Seq[String]])
+              _    <- addTestResult(assertTrue(data == orig))
+              resp <- postEndpoint(s"plugins.remove?profile=$profileId", jsonBody(Seq("test:nonexistent")))
+              _    <- addTestResult(assertTrue(resp.status.code == 400))
+            } yield ())
+          }
+        ),
+
+        suite("update")(
+          test("/update (0 packages, abort update)") {
+            withTestResultRef(ZIO.scoped {
+              for {
+                _ <- removeAll
+                _ <- wsEndpoint(s"update?profile=$profileId",
+                       respond = {
+                         case msg: api.PromptMessage.ConfirmUpdatePlan =>
+                           for {
+                             _  <- addTestResult(assertTrue(
+                                     msg.toRemove.isEmpty,
+                                     msg.toInstall.isEmpty,
+                                     msg.choices == Seq("Yes", "No"),
+                                   ))
+                           } yield msg.responses("No")
+                       },
+                       checkMessages = queue => (for {
+                         _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/prompt/confirmation/update/plan")))
+                         _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/error/aborted")))
+                       } yield ()),
+                     )
+              } yield ()
+            })
+          },
+          test("/update (0 packages, everything up-to-date)") {
+            withTestResultRef(ZIO.scoped {
+              for {
+                _  <- removeAll
+                _  <- wsEndpoint(s"update?profile=$profileId",
+                        respond = {
+                        case msg: api.PromptMessage.ConfirmUpdatePlan =>
+                          for {
+                            _  <- addTestResult(assertTrue(
+                                    msg.toRemove.isEmpty,
+                                    msg.toInstall.isEmpty,
+                                    msg.choices == Seq("Yes", "No"),
+                                  ))
+                          } yield msg.responses("Yes")
+                      },
+                      checkMessages = queue => (for {
+                        _  <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/prompt/confirmation/update/plan")))
+                        _  <- queue.take.flatMap(f => addTestResult(assertTrue(f.json == jsonOk)))
+                      } yield ()),
+                    )
+              } yield ()
+            })
+          },
+          test("/update (1 package with 2 dependencies, with variant, with download progress)") {
+            withTestResultRef(ZIO.scoped {
+              for {
+                _ <- removeAll
+                _ <- postEndpoint(s"plugins.add?profile=$profileId", jsonBody(Seq("memo:demo-package"))).flatMap(isOk200)
+                _ <- wsEndpoint(s"update?profile=$profileId",
+                        respond = {
+                        case msg: api.PromptMessage.ChooseVariant =>
+                          for {
+                            _  <- addTestResult(assertTrue(
+                                    msg.`package`.orgName == "memo:package-template-variants",
+                                    msg.label == "driveside",
+                                    msg.choices == Seq("right", "left"),
+                                  ))
+                          } yield msg.responses("right")
+                        case msg: api.PromptMessage.ConfirmUpdatePlan =>
+                          for {
+                            _  <- addTestResult(assertTrue(
+                                    msg.toRemove.isEmpty,
+                                    msg.toInstall.length == 3,
+                                    msg.choices == Seq("Yes", "No"),
+                                  ))
+                          } yield msg.responses("Yes")
+                        case msg: api.PromptMessage.ConfirmInstallation =>
+                          for {
+                            _  <- addTestResult(assertTrue(
+                                    msg.warnings.size == 1,
+                                    msg.warnings("memo:package-template-basic").size == 2,
+                                    msg.choices == Seq("Yes", "No"),
+                                  ))
+                          } yield msg.responses("Yes")
+                      },
+                      checkMessages = queue => (for {
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/started")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/length")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/intermediate")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/finished")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/started")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/length")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/intermediate")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/finished")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/started")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/length")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/intermediate")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/finished")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/prompt/choice/update/variant")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/started")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/length")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/intermediate")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/finished")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/started")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/length")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/intermediate")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/finished")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/started")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/length")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/intermediate")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/finished")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/started")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/length")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/intermediate")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/finished")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/started")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/length")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/intermediate")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/finished")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/started")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/length")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/intermediate")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/finished")))
+                        _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/prompt/confirmation/update/plan")))
+                        // from here on, two downloads in parallel
+                        maxDownloads = 2
+                        _    <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/started")))
+                        _    <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/download/started")))
+                        msgs <- queue.takeN(22).map(_.map(_.json("$type").str))
+                        _    <- ZIO.foldLeft(msgs)(2) { (numActive, progType) =>
+                                  for {
+                                    _ <- addTestResult(assertTrue(numActive >= 0, numActive <= maxDownloads))
+                                  } yield progType match {
+                                    case "/progress/download/started" => numActive + 1
+                                    case "/progress/download/finished" => numActive - 1
+                                    case _ => numActive
+                                  }
+                                }
+                        _    <- addTestResult(assertTrue(msgs.groupMapReduce(identity)(_ => 1)(_ + _) == Map(
+                                  "/progress/download/length" -> 6,
+                                  "/progress/download/intermediate" -> 6,
+                                  "/progress/download/finished" -> 6,
+                                  "/progress/download/started" -> 4,
+                                )))
+                        _    <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/update/extraction")))
+                        _    <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/update/extraction")))
+                        _    <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/update/extraction")))
+                        _    <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/prompt/confirmation/update/warnings")))
+                        _    <- queue.take.flatMap(f => addTestResult(assertTrue(f.json == jsonOk)))
+                      } yield ()),
+                    )
+              } yield ()
+            })
+          },
+          test("/plugins.installed.list") {
+            withTestResultRef(for {
+              data <- getEndpoint(s"plugins.installed.list?profile=$profileId").flatMap(getBody200[Seq[ujson.Value]])
+              _    <- addTestResult(assertTrue(
+                        data.arr.length == 3,
+                        data.arr.toSet == Set(
+                          Obj("package" -> "memo:demo-package", "version" -> "1.0", "variant" -> Obj(), "explicit" -> true),
+                          Obj("package" -> "memo:package-template-basic", "version" -> "2.0", "variant" -> Obj(), "explicit" -> false),
+                          Obj("package" -> "memo:package-template-variants", "version" -> "1.0", "variant" -> Obj("driveside" -> "right"), "explicit" -> false),
+                        ),
+                      ))
+            } yield ())
+          },
+          test("/variants.list") {
+            withTestResultRef(for {
+              data <- getEndpoint(s"variants.list?profile=$profileId").flatMap(getBody200[ujson.Value])
+              _    <- addTestResult(assertTrue(data == Obj("driveside" -> "right")))
+            } yield ())
+          },
+          test("/variants.reset") {
+            withTestResultRef(for {
+              _    <- postEndpoint(s"variants.reset?profile=$profileId", jsonBody(Seq("driveside"))).flatMap(isOk200)
+              resp <- postEndpoint(s"variants.reset?profile=$profileId", jsonBody(Seq("driveside")))
+              _    <- addTestResult(assertTrue(resp.status.code == 400))
+              data <- getEndpoint(s"variants.list?profile=$profileId").flatMap(getBody200[ujson.Value])
+              _    <- addTestResult(assertTrue(data == Obj()))
+            } yield ())
+          },
+          test("/update (switching variant)") {
+            withTestResultRef(ZIO.scoped {
+              for {
+                pkgs   <- getEndpoint(s"plugins.installed.list?profile=$profileId").flatMap(getBody200[Seq[api.InstalledPkg]])
+                _      <- addTestResult(assertTrue(pkgs.exists(pkg => pkg.variant.get("driveside").contains("right"))))
+                _      <- wsEndpoint(s"update?profile=$profileId",
+                            respond = {
+                              case msg: api.PromptMessage.ChooseVariant =>
+                                for {
+                                  _  <- addTestResult(assertTrue(
+                                          msg.label == "driveside",
+                                          msg.choices == Seq("right", "left"),
+                                        ))
+                                } yield msg.responses("left")
+                              case msg: api.PromptMessage.ConfirmUpdatePlan =>
+                                for {
+                                  _  <- addTestResult(assertTrue(
+                                          msg.toRemove.length == 1,
+                                          msg.toInstall.length == 1,
+                                          msg.toInstall(0).`package` == msg.toRemove(0).`package`,
+                                          msg.toInstall(0).version == msg.toRemove(0).version,
+                                          msg.toInstall(0).variant != msg.toRemove(0).variant,
+                                          msg.choices == Seq("Yes", "No"),
+                                        ))
+                                } yield msg.responses("Yes")
+                              case msg: api.PromptMessage.ConfirmInstallation =>
+                                for {
+                                  _  <- addTestResult(assertTrue(
+                                          msg.warnings.size == 0,
+                                          msg.choices == Seq("Yes", "No"),
+                                        ))
+                                } yield msg.responses("Yes")
+                            },
+                            filter = msg => !msg.json("$type").str.startsWith("/progress/download"),
+                            checkMessages = queue => (for {
+                              _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/prompt/choice/update/variant")))
+                              _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/prompt/confirmation/update/plan")))
+                              _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/progress/update/extraction")))
+                              _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json("$type").str == "/prompt/confirmation/update/warnings")))
+                              _ <- queue.take.flatMap(f => addTestResult(assertTrue(f.json == jsonOk)))
+                            } yield ()),
+                          )
+              } yield ()
+            })
+          },
+        ),
+
+      )
+    }).provideSomeLayerShared(fileServerLayer)  // shared across all tests
+      .provideSomeLayer(currentProfileLayer),
+
+  ).provideShared(profilesDirLayer, serverLayer, Client.default)  // shared across all tests
+    @@ TestAspect.sequential @@ TestAspect.withLiveClock @@ TestAspect.timeout(30.seconds)
+
+}

--- a/src/test/scala/sc4pac/CliSpecZIO.scala
+++ b/src/test/scala/sc4pac/CliSpecZIO.scala
@@ -1,0 +1,24 @@
+// package io.github.memo33.sc4pac
+
+// import zio.*
+// import zio.test.*
+
+// object CliSpecZIO extends ZIOSpecDefault {
+
+//   def spec = suite("CliSpecZIO") {
+//     val port: Int = scala.util.Random.between(50000, 60000)
+//     test("server should time-out") {
+//       for {
+//         _  <- ZIO.attempt {  // TODO testing this requires circumventing System.exit
+//                 cli.CliMain.main(Array[String](
+//                   "server",
+//                   "--profiles-dir", "target/test-profiles",
+//                   "--auto-shutdown=true",
+//                   "--port", port.toString,
+//                 ))
+//               }
+//       } yield assertTrue(true)
+//     }
+//   }
+
+// }


### PR DESCRIPTION
Copying of symlinks fails on Windows, if the `temp` folder and the Plugins folder are on different drives. This is related to an earlier issue in which _moving_ files between drives failed. Instead, the files need to be _copied_ (with symlinks in mind, for DLLs).

Additionally, potential other errors in this final `update` step of moving files into the Plugins folder will now be reported in the GUI as well.