### PR TITLE
extend yaml format to accept arrays of packages and assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- new `packages` and `assets` attributes for YAML files, which allows using YAML anchors, aliases and overrides across multiple packages in the same document (#35)
+
 ### Fixed
 - improved error handling while reading or writing JSON files
 - improved error handling in API websocket communication

--- a/channel-testing/yaml/memo/conflicting-package.yaml
+++ b/channel-testing/yaml/memo/conflicting-package.yaml
@@ -1,6 +1,9 @@
-group: "memo"
-name: "conflicting-package"
-version: "1.0"
-subfolder: "150-mods"
-conflicting:
-- "memo:package-template-variants"
+assets: []
+
+packages:
+- group: "memo"
+  name: "conflicting-package"
+  version: "1.0"
+  subfolder: "150-mods"
+  conflicting:
+  - "memo:package-template-variants"


### PR DESCRIPTION
Instead of separating multiple packages and assets by `---`, this now allows to place all definitions in arrays `packages` and optionally `assets`.

The intention is to allow multiple packages in a single YAML document, so that YAML _anchors_, _aliases_ and _overrides_ can be used across packages in the same file to reduce repetition.

Example:
```yaml
packages:
  - group: &g pkg-group
    name: pkg-name
    version: &v "1.2.3"
    assets:
      - assetId: the-asset
        include: &p "/folder/"
    # ...
  - group: *g
    name: pkg-name2
    version: *v
    assets:
      - assetId: the-asset
        exclude: *p
    # ...
```

CC: @noah-severyn @sebamarynissen @Zasco 