### PR TITLE
add `test` command

### DIFF
--- a/src/main/scala/sc4pac/Data.scala
+++ b/src/main/scala/sc4pac/Data.scala
@@ -369,4 +369,8 @@ object JsonData extends SharedData {
     channels: Seq[Uri] = Seq.empty,
   ) derives ReadWriter
 
+  sealed trait Warning { def value: String }
+  class InformativeWarning(val value: String) extends Warning
+  class UnexpectedWarning(val value: String) extends Warning
+
 }

--- a/src/main/scala/sc4pac/Prompter.scala
+++ b/src/main/scala/sc4pac/Prompter.scala
@@ -18,7 +18,7 @@ trait Prompter {
 
   def promptForDownloadMirror(url: java.net.URI, reason: error.DownloadFailed): Task[Either[Boolean, os.Path]]
 
-  def confirmInstallationWarnings(warnings: Seq[(BareModule, Seq[String])]): Task[Boolean]
+  def confirmInstallationWarnings(warnings: Seq[(BareModule, Seq[JD.Warning])]): Task[Boolean]
 
   def confirmDllsInstalled(dllsInstalled: Seq[Sc4pac.StageResult.DllInstalled]): Task[Boolean]
 
@@ -135,7 +135,7 @@ class CliPrompter(logger: CliLogger, autoYes: Boolean) extends Prompter {
     )
   }
 
-  def confirmInstallationWarnings(warnings: Seq[(BareModule, Seq[String])]): Task[Boolean] = {
+  def confirmInstallationWarnings(warnings: Seq[(BareModule, Seq[JD.Warning])]): Task[Boolean] = {
     if (warnings.isEmpty || autoYes) ZIO.succeed(true)  // if --yes flag is present, always continue
     else Prompt.ifInteractive(
       onTrue = Prompt.yesNo("Continue despite warnings?"),

--- a/src/main/scala/sc4pac/api/logger.scala
+++ b/src/main/scala/sc4pac/api/logger.scala
@@ -193,8 +193,8 @@ class WebSocketPrompter(wsChannel: zio.http.WebSocketChannel, logger: WebSocketL
     }
   }
 
-  def confirmInstallationWarnings(warnings: Seq[(BareModule, Seq[String])]): Task[Boolean] = {
-    sendPrompt(PromptMessage.ConfirmInstallation(warnings.toMap)).map(_.body.str == yes)
+  def confirmInstallationWarnings(warnings: Seq[(BareModule, Seq[JD.Warning])]): Task[Boolean] = {
+    sendPrompt(PromptMessage.ConfirmInstallation(warnings.map { case (pkg, ws) => (pkg, ws.map(_.value)) }.toMap)).map(_.body.str == yes)
   }
 
   def confirmDllsInstalled(dllsInstalled: Seq[Sc4pac.StageResult.DllInstalled]): Task[Boolean] = {

--- a/src/main/scala/sc4pac/cli.scala
+++ b/src/main/scala/sc4pac/cli.scala
@@ -549,7 +549,7 @@ object Commands {
             logger <- ZIO.service[Logger]
             archive = java.io.File(input)
             destination = os.Path(java.nio.file.Paths.get(options.output), os.pwd)
-            stagingRoot <- Sc4pac.makeTempStagingDir(destination, logger)
+            stagingDirs <- Sc4pac.makeStagingDirs(destination, logger)
             assetData = JD.AssetReference(assetId = "dummy-asset", include = options.include, exclude = options.exclude)
             (recipe, regexWarnings) = Extractor.InstallRecipe.fromAssetReference(assetData, variant = Map.empty)  // variant is not needed, as there aren't any conditionals in our dummy asset
             (_, usedPatterns) <- ZIO.attemptBlocking {
@@ -558,9 +558,9 @@ object Commands {
                 fallbackFilename = None,
                 destination = destination,
                 recipe = recipe,
-                jarExtractionOpt = Some(Extractor.JarExtraction(stagingRoot / "nested")),
+                jarExtractionOpt = Some(Extractor.JarExtraction(stagingDirs.nested)),
                 hints = Option(options.clickteamVersion).filter(_.nonEmpty).map(v => JD.ArchiveType(format = JD.ArchiveType.clickteamFormat, version = v)),
-                stagingRoot = stagingRoot,
+                stagingRoot = stagingDirs.root,
                 validate = false,  // to allow extracting non-DBPF files such as DLL files
               )
             }

--- a/src/main/scala/sc4pac/cli.scala
+++ b/src/main/scala/sc4pac/cli.scala
@@ -564,7 +564,7 @@ object Commands {
                 validate = false,  // to allow extracting non-DBPF files such as DLL files
               )
             }
-            _ <- ZIO.foreachDiscard(regexWarnings ++ recipe.usedPatternWarnings(usedPatterns, BareAsset(ModuleName(assetData.assetId)), short = true)) { msg => ZIO.succeed(logger.warn(msg)) }
+            _ <- ZIO.foreachDiscard(regexWarnings ++ recipe.usedPatternWarnings(usedPatterns, BareAsset(ModuleName(assetData.assetId)), short = true)) { msg => ZIO.succeed(logger.warn(msg.value)) }
           } yield ())
           runMainExit(task.provideSomeLayer(zio.ZLayer.succeed(CliLogger())), exit)
         case _ => error(caseapp.core.Error.Other("A single argument is needed: input-archive-file"))

--- a/src/main/scala/sc4pac/extractor.scala
+++ b/src/main/scala/sc4pac/extractor.scala
@@ -10,6 +10,7 @@ import scala.collection.mutable.Builder
 import zio.Chunk
 
 import sc4pac.JsonData as JD
+import JD.Warning
 import sc4pac.error.{ExtractionFailed, ChecksumError, NotADbpfFile}
 
 object Extractor {
@@ -77,12 +78,12 @@ object Extractor {
         Seq.empty
       } else {
         val msg = s"These inclusion/exclusion patterns did not match any files in the asset ${asset.assetId.value}: " + unused.mkString(" ")
-        Seq(
+        Seq(JD.UnexpectedWarning(
           if (!short)
             "The package metadata seems to be out-of-date, so the installed plugin files might be incomplete. " +
             "Please report this to the maintainers of the package metadata. " + msg
           else msg
-        )
+        ))
       }
     }
   }
@@ -93,7 +94,7 @@ object Extractor {
         Some(Pattern.compile(s, Pattern.CASE_INSENSITIVE))
       } catch {
         case e: java.util.regex.PatternSyntaxException =>
-          warnings += s"The package metadata contains a malformed regex: $e"
+          warnings += JD.UnexpectedWarning(s"The package metadata contains a malformed regex: $e")
           None
       }
       val matchingConditions =

--- a/src/main/scala/sc4pac/package.scala
+++ b/src/main/scala/sc4pac/package.scala
@@ -1,7 +1,6 @@
 package io.github.memo33
 package object sc4pac {
   type ErrStr = String
-  type Warning = String
   type Variant = Map[String, String]
   type ProfileId = String
 


### PR DESCRIPTION
This command downloads and installs a given package (temporarily), without any of its dependencies.
If the package has variants, many different variants are tested simultaneously (pairwise coverage of combinations).

Typical errors detected:

- some include/exclude patterns do not match any files (e.g. after updating to a new version of an asset)
- checksum errors
- extraction failures (e.g. if an asset is lacking a Clickteam installer designation)
- errors affecting some but not all variants

(Eventually, the goal is to add a new GH action that runs `sc4pac test` after a successful lint.)

CC: @sebamarynissen @noah-severyn