### PR TITLE
prevent potential json file corruption by writing to temporary file instead

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -79,7 +79,7 @@ jobs:
           cat >sc4pac-plugins.json <<EOL
           {
             "config": {
-              "pluginsRoot": "$GITHUB_WORKSPACE/Documents/SimCity 4/Plugins",
+              "pluginsRoot": "$(echo "$GITHUB_WORKSPACE" | tr '\\' '/')/Documents/SimCity 4/Plugins",
               "cacheRoot": "tmp_build/cache",
               "tempRoot": "tmp_build/temp",
               "variant": {"config:sc4-edition:edition": "Windows-digital"},

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -118,7 +118,7 @@ jobs:
           ./sc4pac server --port 51500 &
           PID1="$(echo $!)"
           echo "==> Started process 1: PID1=$PID1"
-          sleep 10
+          sleep 20
           {
             EXIT_CODE2=0;
             ./sc4pac server --port 51500 || EXIT_CODE2=$?;
@@ -128,7 +128,7 @@ jobs:
           } &
           PID2="$(echo $!)"
           echo "==> Started process 2: PID2=$PID2"
-          sleep 10
+          sleep 20
           echo "==> Terminating process 2"
           ! { kill "$PID2" 2&>/dev/null && echo "unexpected timeout: 2nd server command was too slow"; }
           wait "$PID2"

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -79,7 +79,7 @@ jobs:
           cat >sc4pac-plugins.json <<EOL
           {
             "config": {
-              "pluginsRoot": "$HOME/Documents/SimCity 4/Plugins",
+              "pluginsRoot": "$GITHUB_WORKSPACE/Documents/SimCity 4/Plugins",
               "cacheRoot": "tmp_build/cache",
               "tempRoot": "tmp_build/temp",
               "variant": {"config:sc4-edition:edition": "Windows-digital"},
@@ -98,6 +98,8 @@ jobs:
         run: |
           .\sc4pac add memo:submenus-dll
           .\sc4pac update -y
+          # set installed folders as read-only to test against https://github.com/memo33/sc4pac-tools/issues/40
+          Get-ChildItem -Path "$env:GITHUB_WORKSPACE\Documents\SimCity 4\Plugins" -Recurse -Directory | % { $_.Attributes += 'ReadOnly' }
           .\sc4pac remove memo:submenus-dll
           .\sc4pac update -y
       - name: Install and uninstall a package (Linux)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - a problem in which the profiles configuration directory could not be determined on Windows ([#32][gui32])
   (As a result of this change, in rare cases the default cache location can change from `%USERPROFILE%\sc4pac\cache` to `%LOCALAPPDATA%\io.github.memo33\sc4pac\cache`.)
 - resolved compatibility issue with OneDrive which prevented updating or uninstalling packages if Plugins were stored on OneDrive (#40)
+- a rare issue in which a profile JSON file could get corrupted, making the profile unusable (#41)
 
 [gui32]: https://github.com/memo33/sc4pac-gui/issues/32
 

--- a/build.sbt
+++ b/build.sbt
@@ -80,8 +80,6 @@ assembly / assemblyMergeStrategy := {
 val coursierVersion = "2.1.2"
 libraryDependencies += "io.get-coursier" %% "coursier-cache" % coursierVersion cross CrossVersion.for3Use2_13  // resolver, not yet available for scala 3
 
-libraryDependencies += "dev.zio" %% "zio-nio" % "2.0.2" exclude("org.scala-lang.modules", "scala-collection-compat_3")  // solves version conflict with coursier (compat package is empty in both 2.13 and 3 anyway)
-
 libraryDependencies += "dev.zio" %% "zio" % "2.1.12"  // IO
 
 libraryDependencies += "com.lihaoyi" %% "os-lib" % "0.11.1"  // file system utilities

--- a/src/main/scala/sc4pac/ChannelUtil.scala
+++ b/src/main/scala/sc4pac/ChannelUtil.scala
@@ -230,7 +230,7 @@ object ChannelUtil {
           os.temp.dir(outputDir, prefix = "json", deleteOnExit = true)  // tempJsonDir
         }
       )(  /*release*/  // deleteOnExit does not seem to work reliably, so explicitly delete temp folder after use
-        tempJsonDir => ZIO.succeed(os.remove.all(tempJsonDir))
+        tempJsonDir => ZIO.succeed(Sc4pac.removeAllForcibly(tempJsonDir))
       ){ tempJsonDir =>  /*use*/
         packagesTask.flatMap(writeChannel(_, tempJsonDir))
       }

--- a/src/main/scala/sc4pac/Constants.scala
+++ b/src/main/scala/sc4pac/Constants.scala
@@ -86,4 +86,6 @@ object Constants {
   }
 
   def isDll(path: os.Path): Boolean = path.last.toLowerCase(java.util.Locale.ENGLISH).endsWith(".dll")
+
+  lazy val isPosix = java.nio.file.FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
 }

--- a/src/main/scala/sc4pac/JsonIo.scala
+++ b/src/main/scala/sc4pac/JsonIo.scala
@@ -58,6 +58,7 @@ object JsonIo {
       for {
         _      <- channel.truncate(size = 0)
         unit   <- channel.writeChunk(zio.Chunk.fromArray(arr), position = 0)
+        _      <- channel.force(metaData = false)
       } yield unit
     }
 


### PR DESCRIPTION
There has been a very small number of reports of cases where a JSON file got corrupted during write. The corrupted file had size 0, so probably the subsequent write after file truncation was not properly executed.

The implementation is now changed to first write the file contents to a temporary file, and only if that is successful replace the original file.