### PR TITLE
Fix wiki link and improve clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Each Profile corresponds to a Plugins folder.
 
 !> Important: Make sure to select distinct locations for all your Plugins folders to avoid interference between Profiles.
 
-?> You can use the [SC4 launch parameter](https://www.wiki.sc4devotion.com/index.php?title=Shortcut_Parameters#User_Dir) `-UserDir:"..."`
-   to start the game with a custom location for the Plugins folder.
+?> You can use the [SC4 launch parameter](https://wiki.sc4devotion.com/index.php?title=Shortcut_Parameters#User_Dir) `-UserDir:"..."`
+   to start the game with a custom location for the user's game directory, which contains the `Plugins` folder (and `Regions` folder).
 
 
 ## Uninstalling


### PR DESCRIPTION
Updated the SC4 launch parameter link to the SC4D encyclopedia and clarified the description.
Same as https://github.com/memo33/sc4pac/pull/192